### PR TITLE
Return flat jids array from #jobs

### DIFF
--- a/lib/sidekiq/batch/middleware.rb
+++ b/lib/sidekiq/batch/middleware.rb
@@ -6,7 +6,7 @@ module Sidekiq
       class ClientMiddleware
         def call(_worker, msg, _queue, _redis_pool = nil)
           if (batch = Thread.current[:bid])
-            batch.increment_job_queue([ msg['jid'] ]) if (msg[:bid] = batch.bid)
+            batch.increment_job_queue(msg['jid']) if (msg[:bid] = batch.bid)
           end
           yield
         end


### PR DESCRIPTION
```ruby
batch = Sidekiq::Batch.new
jids = batch.jobs { 3.times { MyWorker.perform_async } }

# old
jids # => [[jid], [jid], [jid]]

#  pull request
jids # => [jid, jid, jid]
```