### PR TITLE
Rename thread var to :batch to reflect its type

### DIFF
--- a/lib/sidekiq/batch.rb
+++ b/lib/sidekiq/batch.rb
@@ -54,7 +54,7 @@ module Sidekiq
 
       begin
         if !@existing && !@initialized
-          parent_bid = Thread.current[:bid].bid if Thread.current[:bid]
+          parent_bid = Thread.current[:batch].bid if Thread.current[:batch]
 
           Sidekiq.redis do |r|
             r.multi do
@@ -70,11 +70,11 @@ module Sidekiq
         @ready_to_queue = []
 
         begin
-          parent = Thread.current[:bid]
-          Thread.current[:bid] = self
+          parent = Thread.current[:batch]
+          Thread.current[:batch] = self
           yield
         ensure
-          Thread.current[:bid] = parent
+          Thread.current[:batch] = parent
         end
 
         return [] if @ready_to_queue.size == 0

--- a/lib/sidekiq/batch/extension/worker.rb
+++ b/lib/sidekiq/batch/extension/worker.rb
@@ -1,11 +1,11 @@
 module Sidekiq::Batch::Extension
   module Worker
     def bid
-      Thread.current[:bid]
+      Thread.current[:batch].bid
     end
 
     def batch
-      Sidekiq::Batch.new(Thread.current[:bid].bid) if Thread.current[:bid]
+      Thread.current[:batch]
     end
 
     def valid_within_batch?

--- a/spec/sidekiq/batch/middleware_spec.rb
+++ b/spec/sidekiq/batch/middleware_spec.rb
@@ -56,7 +56,7 @@ describe Sidekiq::Batch::Middleware do
     context 'when in batch' do
       let(:bid) { 'SAMPLEBID' }
       let(:jid) { 'SAMPLEJID' }
-      before { Thread.current[:bid] = Sidekiq::Batch.new(bid) }
+      before { Thread.current[:batch] = Sidekiq::Batch.new(bid) }
 
       it 'yields' do
         yielded = false

--- a/spec/sidekiq/batch_spec.rb
+++ b/spec/sidekiq/batch_spec.rb
@@ -70,7 +70,7 @@ describe Sidekiq::Batch do
     it 'sets Thread.current bid' do
       batch = Sidekiq::Batch.new
       batch.jobs do
-        expect(Thread.current[:bid]).to eq(batch)
+        expect(Thread.current[:batch]).to eq(batch)
       end
     end
   end


### PR DESCRIPTION
Currently the middleware and batch set the `:bid` fiber local variable to the current batch. The name conflicts with the type and leads to confusing code like `Thread.current[:bid].bid`

This PR renames the variable the batch is set on to `:batch` and updates the `bid` method in the worker to return the batch id instead of the batch. This is in line with the Sidekiq pro API and will help keep the path to or from free of obstacles.