### PR TITLE
Improve nested batches

### DIFF
--- a/lib/sidekiq/batch.rb
+++ b/lib/sidekiq/batch.rb
@@ -212,11 +212,11 @@ module Sidekiq
           Sidekiq::Client.push_bulk(
             'class' => Sidekiq::Batch::Callback::Worker,
             'args' => callbacks.reduce([]) do |memo, jcb|
-              cb = Sidekiq.load_json(jcb)
+              cb = Sidekiq.load_json(jcb) || {'callback': nil}
               memo << [cb['callback'], event, cb['opts'], bid, parent_bid]
             end,
             'queue' => queue ||= 'default'
-          ) unless callbacks.empty?
+          )
         ensure
           cleanup_redis(bid) if event == :success
         end

--- a/lib/sidekiq/batch.rb
+++ b/lib/sidekiq/batch.rb
@@ -83,7 +83,7 @@ module Sidekiq
           r.multi do
             if parent_bid
               r.hincrby("BID-#{parent_bid}", "children", 1)
-              r.hincrby(@bidkey, "total", @ready_to_queue.size)
+              r.hincrby("BID-#{parent_bid}", "total", @ready_to_queue.size)
               r.expire("BID-#{parent_bid}", BID_EXPIRE_TTL)
             end
 

--- a/lib/sidekiq/batch.rb
+++ b/lib/sidekiq/batch.rb
@@ -176,8 +176,8 @@ module Sidekiq
 
         Sidekiq.logger.info "done: #{jid} in batch #{bid}"
 
-        enqueue_callbacks(:complete, bid) if pending.to_i == failed.to_i && children == complete
-        enqueue_callbacks(:success, bid) if pending.to_i.zero? && children == success
+        # if complete or successfull call complete callback (the complete callback may then call successful)
+        enqueue_callbacks(:complete, bid) if (pending.to_i == failed.to_i && children == complete) || (pending.to_i.zero? && children == success)
       end
 
       def enqueue_callbacks(event, bid)

--- a/lib/sidekiq/batch/callback.rb
+++ b/lib/sidekiq/batch/callback.rb
@@ -21,39 +21,27 @@ module Sidekiq
 
         def success(bid, status, parent_bid)
           if (parent_bid)
-            _, _, success, pending, children = Sidekiq.redis do |r|
+            _, _, success, _, complete, pending, children, failure = Sidekiq.redis do |r|
               r.multi do
                 r.sadd("BID-#{parent_bid}-success", bid)
                 r.expire("BID-#{parent_bid}-success", Sidekiq::Batch::BID_EXPIRE_TTL)
                 r.scard("BID-#{parent_bid}-success")
-                r.hincrby("BID-#{parent_bid}", "pending", 0)
-                r.hincrby("BID-#{parent_bid}", "children", 0)
-              end
-            end
-
-            Batch.enqueue_callbacks(:success, parent_bid) if pending.to_i.zero? && children == success
-          end
-
-          Sidekiq.redis do |r|
-            r.del "BID-#{bid}-success", "BID-#{bid}-complete", "BID-#{bid}-jids", "BID-#{bid}-failed"
-          end
-        end
-
-        def complete(bid, status, parent_bid)
-          if (parent_bid)
-            _, complete, pending, children, failure = Sidekiq.redis do |r|
-              r.multi do
                 r.sadd("BID-#{parent_bid}-complete", bid)
                 r.scard("BID-#{parent_bid}-complete")
                 r.hincrby("BID-#{parent_bid}", "pending", 0)
                 r.hincrby("BID-#{parent_bid}", "children", 0)
-                r.hlen("BID-#{parent_bid}-failed")
+                r.scard("BID-#{parent_bid}-failed")
               end
             end
 
+            # if job finished successfully and parent finished successfully call parent success callback
+            Batch.enqueue_callbacks(:success, parent_bid) if pending.to_i.zero? && children == success
+            # if job finished successfully and parent batch completed call parent complete callback
             Batch.enqueue_callbacks(:complete, parent_bid) if complete == children && pending == failure
           end
+        end
 
+        def complete(bid, status, parent_bid)
           pending, children, success = Sidekiq.redis do |r|
             r.multi do
               r.hincrby("BID-#{bid}", "pending", 0)
@@ -62,10 +50,27 @@ module Sidekiq
             end
           end
 
+          # if we batch was successful run success callback
           Batch.enqueue_callbacks(:success, bid) if pending.to_i.zero? && children == success
 
-        end
+          # if batch was not successfull check and see if its parent is complete
+          # if the parent is complete we trigger the complete callback
+          # We don't want to run this if the batch was successfull because the success
+          # callback may add more jobs to the batch
+          if parent_bid and not (pending.to_i.zero? && children == success)
+            _, complete, pending, children, failure = Sidekiq.redis do |r|
+              r.multi do
+                r.sadd("BID-#{parent_bid}-complete", bid)
+                r.scard("BID-#{parent_bid}-complete")
+                r.hincrby("BID-#{parent_bid}", "pending", 0)
+                r.hincrby("BID-#{parent_bid}", "children", 0)
+                r.scard("BID-#{parent_bid}-failed")
+              end
+            end
 
+            Batch.enqueue_callbacks(:complete, parent_bid) if complete == children && pending == failure
+          end
+        end
       end
     end
   end

--- a/spec/sidekiq/batch_spec.rb
+++ b/spec/sidekiq/batch_spec.rb
@@ -195,9 +195,8 @@ describe Sidekiq::Batch do
 
     context 'success' do
       before { batch.on(:complete, Object) }
-      it 'tries to call complete and success callbacks' do
+      it 'tries to call complete callback' do
         expect(Sidekiq::Batch).to receive(:enqueue_callbacks).with(:complete, bid)
-        expect(Sidekiq::Batch).to receive(:enqueue_callbacks).with(:success, bid)
         Sidekiq::Batch.process_successful_job(bid, jid)
       end
 
@@ -248,7 +247,7 @@ describe Sidekiq::Batch do
         end
       end
     end
-
+    
     context 'when already called' do
       it 'returns and does not enqueue callbacks' do
         batch = Sidekiq::Batch.new


### PR DESCRIPTION
I've made some changes in order to get nested batches working in a predictable way and enabling them to be used in a workflow similar to https://github.com/mperham/sidekiq/wiki/Really-Complex-Workflows-with-Batches. Without these changes the complete/success callbacks are called at the wrong times, while the batch is still running.

The key things here are ensuring the complete/success callbacks always occur in the same order and making sure callbacks complete before checking the completion/success status of a parent batch.

I've made it so the complete callback is always called first, and then may go on to call the success callback. Also the internal complete callback is always called, even if there is no user defined callback. This is important to maintain the correct order and so we can check the parent batch, which may have a complete callback while the child batch does not.

This has been working really well for me and seems stable.