### PR TITLE
Update Integration Tests

### DIFF
--- a/spec/integration/nested.rb
+++ b/spec/integration/nested.rb
@@ -84,8 +84,24 @@ end
 
 puts "Overall bid #{batch.bid}"
 
-dump_redis_keys
+out_buf = StringIO.new
+Sidekiq.logger = Logger.new out_buf
 
 Sidekiq::Worker.drain_all
 
-dump_redis_keys
+output = out_buf.string
+puts out_buf.string
+
+describe "sidekiq batch" do
+  it "runs overall complete callback" do
+    expect(output).to include "Overall Complete"
+  end
+
+  it "runs overall success callback" do
+    expect(output).to include "Overall Success"
+  end
+
+  it "cleans redis keys" do
+    expect(redis_keys).to eq([])
+  end
+end

--- a/spec/integration/nested.rb
+++ b/spec/integration/nested.rb
@@ -1,0 +1,91 @@
+require 'integration_helper'
+
+# Tests deep nesting of batches
+# Batches:
+# - Overall (Worker 1)
+#  - Worker 2
+#   - Worker 3
+#    - Worker 4
+
+class Worker1
+  include Sidekiq::Worker
+
+  def perform
+    Sidekiq.logger.info "Work1"
+    batch = Sidekiq::Batch.new
+    batch.on(:success, Worker2)
+    batch.jobs do
+      Worker2.perform_async
+    end
+  end
+end
+
+class Worker2
+  include Sidekiq::Worker
+
+  def perform
+    Sidekiq.logger.info "Work2"
+    batch = Sidekiq::Batch.new
+    batch.on(:success, Worker3)
+    batch.jobs do
+      Worker3.perform_async
+    end
+  end
+
+  def on_success status, opts
+    Sidekiq.logger.info "Worker 2 Success"
+  end
+end
+
+class Worker3
+  include Sidekiq::Worker
+
+  def perform
+    Sidekiq.logger.info "Work3"
+    batch = Sidekiq::Batch.new
+    batch.on(:success, Worker4)
+    batch.jobs do
+      Worker4.perform_async
+    end
+  end
+
+  def on_success status, opts
+    Sidekiq.logger.info "Worker 3 Success"
+  end
+end
+
+class Worker4
+  include Sidekiq::Worker
+
+  def perform
+    Sidekiq.logger.info "Work4"
+  end
+
+  def on_success status, opts
+    Sidekiq.logger.info "Worker 4 Success"
+  end
+end
+
+
+class SomeClass
+  def on_complete(status, options)
+    Sidekiq.logger.info "Overall Complete #{options} #{status.data}"
+  end
+  def on_success(status, options)
+    Sidekiq.logger.info "Overall Success #{options} #{status.data}"
+  end
+end
+batch = Sidekiq::Batch.new
+batch.on(:success, SomeClass, 'uid' => 3)
+batch.on(:complete, SomeClass, 'uid' => 3)
+batch.jobs do
+  Worker1.perform_async
+end
+
+puts "Overall bid #{batch.bid}"
+
+dump_redis_keys
+
+Sidekiq::Worker.drain_all
+
+dump_redis_keys

--- a/spec/integration/simple.rb
+++ b/spec/integration/simple.rb
@@ -23,10 +23,6 @@ class Worker2
   def perform
     Sidekiq.logger.info "Work2"
   end
-
-  def on_complete status, opts
-    Sidekiq.logger.info "Worker 2 Complete"
-  end
 end
 
 class SomeClass
@@ -47,11 +43,23 @@ end
 
 puts "Overall bid #{batch.bid}"
 
-dump_redis_keys
+out_buf = StringIO.new
+Sidekiq.logger = Logger.new out_buf
 
 Sidekiq::Worker.drain_all
 
-describe("sidekiq batch") do
+output = out_buf.string
+puts out_buf.string
+
+describe "sidekiq batch" do
+  it "runs overall complete callback" do
+    expect(output).to include "Overall Complete"
+  end
+
+  it "runs overall success callback" do
+    expect(output).to include "Overall Success"
+  end
+
   it "cleans redis keys" do
     expect(redis_keys).to eq([])
   end

--- a/spec/integration/simple.rb
+++ b/spec/integration/simple.rb
@@ -1,0 +1,58 @@
+require 'integration_helper'
+
+# Simple nested batch without callbacks
+# Batches:
+# - Overall (Worker1)
+#  - Worker2
+
+class Worker1
+  include Sidekiq::Worker
+
+  def perform
+    Sidekiq.logger.info "Work1"
+    batch = Sidekiq::Batch.new
+    batch.jobs do
+      Worker2.perform_async
+    end
+  end
+end
+
+class Worker2
+  include Sidekiq::Worker
+
+  def perform
+    Sidekiq.logger.info "Work2"
+  end
+
+  def on_complete status, opts
+    Sidekiq.logger.info "Worker 2 Complete"
+  end
+end
+
+class SomeClass
+  def on_complete(status, options)
+    Sidekiq.logger.info "Overall Complete #{options} #{status.data}"
+  end
+  def on_success(status, options)
+    Sidekiq.logger.info "Overall Success #{options} #{status.data}"
+  end
+end
+
+batch = Sidekiq::Batch.new
+batch.on(:success, SomeClass)
+batch.on(:complete, SomeClass)
+batch.jobs do
+  Worker1.perform_async
+end
+
+puts "Overall bid #{batch.bid}"
+
+dump_redis_keys
+
+Sidekiq::Worker.drain_all
+
+describe("sidekiq batch") do
+  it "cleans redis keys" do
+    expect(redis_keys).to eq([])
+  end
+end

--- a/spec/integration/workflow.rb
+++ b/spec/integration/workflow.rb
@@ -1,0 +1,139 @@
+require 'integration_helper'
+
+# Complex workflow with sequential and nested
+# Also test sub batches without callbacks
+# Batches:
+# - Overall
+#  - Worker1
+#   - Worker3
+#  - Worker2 + Worker3
+#   - Worker1
+#    - Worker3
+#  - Worker4
+#  - Worker5
+
+class Callbacks
+  def worker1 status, opts
+    Sidekiq.logger.info "Success 1 #{status.data}"
+
+    overall = Sidekiq::Batch.new status.parent_bid
+    overall.jobs do
+      batch = Sidekiq::Batch.new
+      batch.on(:success, "Callbacks#worker2")
+      batch.jobs do
+        Worker2.perform_async
+      end
+    end
+  end
+
+  def worker2 status, opts
+    Sidekiq.logger.info "Success 2 #{status.data}"
+    overall = Sidekiq::Batch.new status.parent_bid
+    overall.jobs do
+      batch = Sidekiq::Batch.new
+      batch.on(:success, "Callbacks#worker4")
+      batch.jobs do
+        Worker4.perform_async
+      end
+    end
+
+  end
+
+  def worker4 status, opts
+    Sidekiq.logger.info "Success 4 #{status.data}"
+    overall = Sidekiq::Batch.new status.parent_bid
+    overall.jobs do
+      batch = Sidekiq::Batch.new
+      batch.on(:success, "Callbacks#worker5")
+      batch.jobs do
+        Worker5.perform_async
+      end
+    end
+  end
+
+  def worker5 status, opts
+    Sidekiq.logger.info "Success 5 #{status.data}"
+  end
+end
+
+class Worker1
+  include Sidekiq::Worker
+
+  def perform
+    Sidekiq.logger.info "Work 1"
+    batch = Sidekiq::Batch.new
+    batch.jobs do
+      Worker3.perform_async
+    end
+  end
+end
+
+class Worker2
+  include Sidekiq::Worker
+
+  def perform
+    Sidekiq.logger.info "Work 2"
+    if bid
+      batch.jobs do
+        Worker3.perform_async
+      end
+      newb = Sidekiq::Batch.new
+      newb.jobs do
+        Worker1.perform_async
+      end
+    end
+  end
+end
+
+class Worker3
+  include Sidekiq::Worker
+  def perform
+    Sidekiq.logger.info "Work 3"
+  end
+end
+
+class Worker4
+  include Sidekiq::Worker
+  def perform
+    Sidekiq.logger.info "Work 4"
+  end
+end
+
+class Worker5
+  include Sidekiq::Worker
+  def perform
+    Sidekiq.logger.info "Work 5"
+  end
+end
+
+class MyCallback
+  def on_success(status, options)
+    Sidekiq.logger.info "Success Overall #{options} #{status.data}"
+  end
+  alias_method :multi, :on_success
+
+  def on_complete(status, options)
+    Sidekiq.logger.info "Complete Overall #{options} #{status.data}"
+  end
+end
+
+overall = Sidekiq::Batch.new
+overall.on(:success, MyCallback, to: 'success@gmail.com')
+overall.on(:complete, MyCallback, to: 'success@gmail.com')
+overall.jobs do
+  batch1 = Sidekiq::Batch.new
+  batch1.on(:success, "Callbacks#worker1")
+  batch1.jobs do
+    Worker1.perform_async
+  end
+end
+
+puts "Overall bid #{overall.bid}"
+
+dump_redis_keys
+
+puts Sidekiq::Worker.jobs
+
+Sidekiq::Worker.drain_all
+
+dump_redis_keys

--- a/spec/integration_helper.rb
+++ b/spec/integration_helper.rb
@@ -10,7 +10,6 @@ Sidekiq.redis { |r| r.flushdb }
 
 # Sidekiq.logger.level = :debug
 
-
 def redis_keys
   Sidekiq.redis { |r| r.keys('BID-*') }
 end

--- a/spec/integration_helper.rb
+++ b/spec/integration_helper.rb
@@ -1,0 +1,20 @@
+require 'spec_helper'
+require 'sidekiq/batch'
+require 'sidekiq/testing'
+
+Sidekiq::Testing.server_middleware do |chain|
+  chain.add Sidekiq::Batch::Middleware::ServerMiddleware
+end
+
+Sidekiq.redis { |r| r.flushdb }
+
+# Sidekiq.logger.level = :debug
+
+
+def redis_keys
+  Sidekiq.redis { |r| r.keys('BID-*') }
+end
+
+def dump_redis_keys
+  puts redis_keys.inspect
+end


### PR DESCRIPTION
The integration tests have been modified to use fakeredis and sidekiq testing mode. This means the tests can now be run non interactively. Basic rspec expectations have been added to test cleanup of redis keys as well as presence of callbacks in the output. Currently only `integration.rb` functions as intended. This test simply adds to the current batch in the perform method.

A few new tests have been added to exercise more complex workflows. These tests are not passing as this functionality is broken at the moment. I have a PR on the way that will correct this.

`simple.rb` test a nested batch with no registered callbacks
`nested.rb` tests deep nesting with callbacks
`workflow.rb` a complex workflow with nesting and sequential batches

This should help better describe the current functionality and verify new fixes.