### PR TITLE
Callback status and nested batches

### DIFF
--- a/lib/sidekiq/batch.rb
+++ b/lib/sidekiq/batch.rb
@@ -33,6 +33,11 @@ module Sidekiq
       persist_bid_attr('callback_queue', callback_queue)
     end
 
+    def callback_batch=(callback_batch)
+      @callback_batch = callback_batch
+      persist_bid_attr('callback_batch', callback_batch)
+    end
+
     def on(event, callback, options = {})
       return unless %w(success complete).include?(event.to_s)
       callback_key = "#{@bidkey}-callbacks-#{event}"
@@ -174,7 +179,7 @@ module Sidekiq
           end
         end
 
-        Sidekiq.logger.info "done: #{jid} in batch #{bid}"
+        Sidekiq.logger.debug {"Job success: #{jid} in batch #{bid} children: #{children} complete #{complete} success #{success} pending #{pending} failed #{failed}"}
 
         enqueue_callbacks(:complete, bid) if pending.to_i == failed.to_i && children == complete
         enqueue_callbacks(:success, bid) if pending.to_i.zero? && children == success
@@ -183,39 +188,77 @@ module Sidekiq
       def enqueue_callbacks(event, bid)
         batch_key = "BID-#{bid}"
         callback_key = "#{batch_key}-callbacks-#{event}"
-        needed, _, callbacks, queue, parent_bid = Sidekiq.redis do |r|
+        needed, _, callbacks, queue, parent_bid, callback_batch = Sidekiq.redis do |r|
           r.multi do
             r.hget(batch_key, event)
             r.hset(batch_key, event, true)
             r.smembers(callback_key)
             r.hget(batch_key, "callback_queue")
             r.hget(batch_key, "parent_bid")
+            r.hget(batch_key, "callback_batch")
           end
         end
+        Sidekiq.logger.debug {"Enqueue callback info: bid: #{bid} event: #{event} needed: #{needed}"} if needed == 'true'
+
         return if needed == 'true'
 
-        begin
-          parent_bid = !parent_bid || parent_bid.empty? ? nil : parent_bid    # Basically parent_bid.blank?
-          Sidekiq::Client.push_bulk(
-            'class' => Sidekiq::Batch::Callback::Worker,
-            'args' => callbacks.reduce([]) do |memo, jcb|
-              cb = Sidekiq.load_json(jcb)
-              memo << [cb['callback'], event, cb['opts'], bid, parent_bid]
-            end,
-            'queue' => queue ||= 'default'
-          ) unless callbacks.empty?
-        ensure
-          cleanup_redis(bid) if event == :success
+        queue ||= "default"
+        parent_bid = !parent_bid || parent_bid.empty? ? nil : parent_bid    # Basically parent_bid.blank?
+        callback_args = callbacks.reduce([]) do |memo, jcb|
+          cb = Sidekiq.load_json(jcb)
+          memo << [cb['callback'], event, cb['opts'], bid, parent_bid]
+        end
+
+        Sidekiq.logger.debug {"Enqueue callback bid: #{bid} event: #{event} args: #{callback_args.inspect}"}
+
+        if callback_batch
+          push_callbacks callback_args, queue unless callback_args.empty?
+          return
+        end
+
+        opts = {"bid" => bid, "event" => event}
+
+        if callback_args.empty?
+          # Finalize now
+          finalizer = Sidekiq::Batch::Callback::Finalize.new
+          status = Status.new bid
+          finalizer.dispatch(status, opts)
+        else
+          # Otherwise finalize in sub batch success callback
+          cb_batch = self.new
+          cb_batch.callback_batch = true
+          Sidekiq.logger.debug {"Adding callback batch: #{cb_batch.bid} for batch: #{bid}"}
+          cb_batch.on(:success, "Sidekiq::Batch::Callback::Finalize#dispatch", opts)
+          cb_batch.jobs do
+            push_callbacks callback_args, queue
+          end
         end
       end
 
       def cleanup_redis(bid)
+        Sidekiq.logger.debug {"Cleaning redis of batch #{bid}"}
         Sidekiq.redis do |r|
-          r.del("BID-#{bid}",
-                "BID-#{bid}-callbacks-complete",
-                "BID-#{bid}-callbacks-success",
-                "BID-#{bid}-failed")
+          r.del(
+            "BID-#{bid}",
+            "BID-#{bid}-callbacks-complete",
+            "BID-#{bid}-callbacks-success",
+            "BID-#{bid}-failed",
+
+            "BID-#{bid}-success",
+            "BID-#{bid}-complete",
+            "BID-#{bid}-jids",
+          )
         end
+      end
+
+    private
+
+      def push_callbacks args, queue
+        Sidekiq::Client.push_bulk(
+          'class' => Sidekiq::Batch::Callback::Worker,
+          'args' => args,
+          'queue' => queue
+        ) unless args.empty?
       end
     end
   end

--- a/lib/sidekiq/batch/status.rb
+++ b/lib/sidekiq/batch/status.rb
@@ -45,13 +45,15 @@ module Sidekiq
 
       def data
         {
+          bid: bid,
           total: total,
           failures: failures,
           pending: pending,
           created_at: created_at,
           complete: complete?,
           failure_info: failure_info,
-          parent_bid: parent_bid
+          parent_bid: parent_bid,
+          child_count: child_count
         }
       end
     end


### PR DESCRIPTION
This is a follow up to the integration test in #25 . I'm making these separately in order to keep the tests mergable and to verify the failing case before the fix.

This PR started as an attempt to fix #13 but evolved rapidly. The problem being the status object passed to the callbacks is empty. The root of this issue is that callbacks are executed asynchronously as a job, but the redis keys holding the status are cleared when the job is pushed to Sidekiq.

To solve this, I added the concept of a "callback" batch. This is a batch that contains only the callbacks of another batch. The redis clean-up code can then be moved to the success callback of this callback batch. This means the status is available until all callbacks have completed.


In the process of testing this, I came across #11 and troubles with nested batches.
It seems the logic to update a parent batch is part of the callback worker and only ever runs if there is a callback of that type registered. This breaks the propagation of events up to the batch parent.

Both of these issues fall into the same category, so the concept of "finalizing" was introduced. The finalizer is called on a batch for an event type when the batch and any callbacks for that event are complete. If there are no callbacks for an event, the finalizer is called synchronously. Otherwise it is run as a success callback on the callback batch.

Moving the event bubbling and redis cleanup to the finalizer solves both these issues and enables some complex workflows.

### Notes/Issues:
 - When creating workflows by appending to the parent batch in a success callback, the complete callback on the parent batch may fire on initial batch completion since the first child batch success callback has not yet modified the parent.
 - Redis is cleared in the success finalizer. This means you have status for all success callbacks. However if you have complete but no success callbacks, the redis status will likely be unavailable.

### Update
After seeing #24 its possible both of the above issues would be solved by ensuring success callbacks run after complete. I will attempt to combine these two approaches.