### PR TITLE
Add KnownBatchBaseKlass

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,3 +42,23 @@ Bug reports and pull requests are welcome on GitHub at https://github.com/breamw
 ## License
 
 The gem is available as open source under the terms of the [MIT License](http://opensource.org/licenses/MIT).
+
+
+## Changes in this fork
+
+There are multiple bugs reported on how the complete/success callback is called on batches.
+This version fixes (tries to fix) 2 bugs (unwanted behaviours): 
+1. The complete callback is called sometimes to early, before batch completion 
+2. The total number of pending jobs from the batch sometimes differ from the initial jobs enqueued initially 
+
+Both issues are caused (in my case) when the jobs from the batch are enqueuing jobs that are not related to the batch. 
+Also this is reproducible only when concurrency is > 1
+
+#### How the fix works:  
+We consider that only the "Allowed" classes can be added to the batch queue.
+To enable this behaviour, the following constants should be set in an initializer:
+```
+Sidekiq::Batch::Extension::KnownBatchBaseKlass::ENABLED = true
+Sidekiq::Batch::Extension::KnownBatchBaseKlass::ALLOWED = [MyBaseBatchWorker].freeze
+```
+By enabling this behaviour, jobs that are enqueued by jobs from our batch, are not added to the batch also. Only the ones that have as an ancestor a base class defined by us. 

--- a/lib/sidekiq/batch/extension/known_batch_base_klass.rb
+++ b/lib/sidekiq/batch/extension/known_batch_base_klass.rb
@@ -1,0 +1,17 @@
+module Sidekiq::Batch::Extension
+  module KnownBatchBaseKlass
+    def enabled?
+      @enabled ||= defined?(ENABLED) ? ENABLED : false
+    end
+
+    def allowed
+      @allowed ||= defined?(ALLOWED) ? ALLOWED : []
+    end
+
+    def allowed?(klass)
+      return true unless enabled?
+
+      (Object.const_get(klass).ancestors & allowed).any?
+    end
+  end
+end

--- a/lib/sidekiq/batch/middleware.rb
+++ b/lib/sidekiq/batch/middleware.rb
@@ -1,11 +1,14 @@
 require_relative 'extension/worker'
+require_relative 'extension/known_batch_base_klass'
 
 module Sidekiq
   class Batch
     module Middleware
       class ClientMiddleware
+        include Sidekiq::Batch::Extension::KnownBatchBaseKlass
+
         def call(_worker, msg, _queue, _redis_pool = nil)
-          if (batch = Thread.current[:batch])
+          if allowed?(msg['class']) && (batch = Thread.current[:batch])
             batch.increment_job_queue(msg['jid']) if (msg[:bid] = batch.bid)
           end
           yield

--- a/spec/integration/allowed_jobs_spec.rb
+++ b/spec/integration/allowed_jobs_spec.rb
@@ -1,0 +1,106 @@
+require_relative '../integration_helper.rb'
+
+class TestWorker
+  include Sidekiq::Worker
+  def perform
+  end
+end
+
+class BaseKnownWorker
+  include Sidekiq::Worker
+  def perform
+  end
+end
+
+class KnownBatchWorker < BaseKnownWorker
+  def perform
+    TestWorker.perform_async
+    TestWorker.perform_one
+  end
+end
+
+describe 'allowed jobs' do
+  context 'when KnownBatchBaseKlass is enabled' do
+    let(:batch) { Sidekiq::Batch.new }
+    let(:bid) { batch.bid }
+
+    before(:each) do
+      Sidekiq::Worker.drain_all
+      Sidekiq::Batch::Extension::KnownBatchBaseKlass::ENABLED = true
+      Sidekiq::Batch::Extension::KnownBatchBaseKlass::ALLOWED = [BaseKnownWorker]
+      batch.on(:complete, KnownBatchWorker)
+      batch.on(:success, KnownBatchWorker)
+
+      batch.jobs do
+        KnownBatchWorker.perform_async
+      end
+    end
+
+    after(:each) do
+      Sidekiq::Batch::Extension::KnownBatchBaseKlass::ENABLED = false
+      Sidekiq::Batch::Extension::KnownBatchBaseKlass::ALLOWED = []
+    end
+
+    it 'should not add other redis jobs into the batch queue' do
+      total = Sidekiq.redis { |r| r.hget("BID-#{bid}", 'total') }
+      expect(total).to eq('1')
+
+      pending = Sidekiq.redis { |r| r.hget("BID-#{bid}", 'pending') }
+      expect(pending).to eq('1')
+    end
+
+    it 'should call complete and success callbacks' do
+      expect(Sidekiq::Batch).to receive(:enqueue_callbacks).with(:complete, anything)
+      expect(Sidekiq::Batch).to receive(:enqueue_callbacks).with(:success, anything)
+
+      Sidekiq::Worker.drain_all
+    end
+
+    it 'should have correct status' do
+      expect(Sidekiq::Batch).to receive(:enqueue_callbacks).with(:complete, anything)
+      expect(Sidekiq::Batch).to receive(:enqueue_callbacks).with(:success, anything)
+
+      Sidekiq::Worker.drain_all
+
+      total = Sidekiq.redis { |r| r.hget("BID-#{bid}", 'total') }
+      expect(total).to eq('1')
+
+      pending = Sidekiq.redis { |r| r.hget("BID-#{bid}", 'pending') }
+      expect(pending).to eq('0')
+    end
+  end
+
+  context 'when KnownBatchBaseKlass is disabled' do
+    let(:batch) { Sidekiq::Batch.new }
+    let(:bid) { batch.bid }
+
+    before(:each) do
+      Sidekiq::Worker.drain_all
+
+      Sidekiq::Batch::Extension::KnownBatchBaseKlass::ENABLED = false
+      Sidekiq::Batch::Extension::KnownBatchBaseKlass::ALLOWED = []
+      batch.on(:complete, KnownBatchWorker)
+
+      batch.jobs do
+        KnownBatchWorker.perform_async
+      end
+    end
+
+    it 'should have the pending status -1 because of the extra job executed by our batch job' do
+      expect(Sidekiq::Batch).to receive(:enqueue_callbacks).with(:complete, anything)
+      expect(Sidekiq::Batch).to receive(:enqueue_callbacks).with(:success, anything)
+
+      total = Sidekiq.redis { |r| r.hget("BID-#{bid}", 'total') }
+      expect(total).to eq('1')
+      pending = Sidekiq.redis { |r| r.hget("BID-#{bid}", 'pending') }
+      expect(pending).to eq('1')
+
+      Sidekiq::Worker.drain_all
+
+      total = Sidekiq.redis { |r| r.hget("BID-#{bid}", 'total') }
+      expect(total).to eq('1')
+      pending = Sidekiq.redis { |r| r.hget("BID-#{bid}", 'pending') }
+      expect(pending).to eq('-1')
+    end
+  end
+end

--- a/spec/sidekiq/batch_spec.rb
+++ b/spec/sidekiq/batch_spec.rb
@@ -60,7 +60,7 @@ describe Sidekiq::Batch do
 
     it 'increments to_process (when started)'
 
-    it 'decrements to_process (when finished)'
+    # it 'decrements to_process (when finished)'
     # it 'calls process_successful_job to wait for block to finish' do
     #   batch = Sidekiq::Batch.new
     #   expect(Sidekiq::Batch).to receive(:process_successful_job).with(batch.bid)


### PR DESCRIPTION
This implementation comes to solve somehow the issue described here: breamware#41.

This is a dirty patch, I know that, but for now, I'm not able to find anything better.

From what I've tested on my project, the issue occurs only when concurrency is bigger than 1.

My simplest real test case is:

Create a batch with 1 Foo job.
the Foo job, at some point, will call Bar.perfrom_async (which will add this job to the batch queue, and execute it)
The on_complete callback is triggered when Bar job is done
The foo job is done
This patch **won't probably fix all** the problems that I found around the closed issues regarding the on_complete callback, but for the simple cases where another job is added to the batch at a later point, this should work.

P.S Adding jobs at a later point is a known feature, but I really think that something else is wrong (probably incrementing the total number of jobs or even the condition that decides if the on_complete callback should or should not be called)

Any advice is more than welcome.