### PR TITLE
switch exists to exists? so that a boolean is returned and not an integer

### DIFF
--- a/lib/sidekiq/batch.rb
+++ b/lib/sidekiq/batch.rb
@@ -130,7 +130,7 @@ module Sidekiq
     end
 
     def valid?(batch = self)
-      valid = !Sidekiq.redis { |r| r.exists("invalidated-bid-#{batch.bid}") }
+      valid = !Sidekiq.redis { |r| r.exists?("invalidated-bid-#{batch.bid}") }
       batch.parent ? valid && valid?(batch.parent) : valid
     end
 


### PR DESCRIPTION
Redis#exists(key) returns an integer now in newer versions of Redis. Switch method to Redis#exists?(key) so that a boolean is returned