### PR TITLE
Ensure batch callbacks aren't run unexpectedly

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,41 @@ Or install it yourself as:
 
 ## Usage
 
-Sidekiq Batch is drop-in replacement for the API from Sidekiq PRO. See https://github.com/mperham/sidekiq/wiki/Batches for usage.
+Sidekiq Batch is MOSTLY a drop-in replacement for the API from Sidekiq PRO. See https://github.com/mperham/sidekiq/wiki/Batches for usage.
+
+## Caveats/Gotchas
+
+Consider the following workflow:
+
+  * Batch Z created
+  * Worker A queued in batch Z
+  * Worker A starts Worker B in batch Z
+  * Worker B completes *before* worker A does
+  * Worker A completes
+
+In the standard configuration, the `on(:success)` and `on(:complete)` callbacks will be triggered when Worker B completes.
+This configuration is the default, simply for legacy reasons. This gem adds the following option to the sidekiq.yml options:
+
+```yaml
+:batch_push_interval: 0
+```
+
+When this value is *absent* (aka legacy), Worker A will only push the increment of batch jobs (aka Worker B) *when it completes*
+
+When this value is set to `0`, Worker A will increment the count as soon as `WorkerB.perform_async` is called
+
+When this value is a positive number, Worker A will wait a maximum of value-seconds before pushing the increment to redis, or until it's done, whichever comes first.
+
+This comes into play if Worker A is queueing thousands of WorkerB jobs, or has some other reason for WorkerB to complete beforehand.
+
+If you are queueing many WorkerB jobs, it is recommended to set this value to something like `3` to avoid thousands of calls to redis, and call WorkerB like so:
+```ruby
+WorkerB.perform_in(4.seconds, some, args)
+```
+this will ensure that the batch callback does not get triggered until WorkerA *and* the last WorkerB job complete.
+
+If WorkerA is just slow for whatever reason, setting to `0` will update the batch status immediately so that the callbacks don't fire.
+
 
 ## Contributing
 

--- a/lib/sidekiq/batch.rb
+++ b/lib/sidekiq/batch.rb
@@ -138,10 +138,10 @@ module Sidekiq
     def should_increment?
       return false unless @incremental_push
       return true if @batch_push_interval == 0 || @queued_jids.length == 1
-
-      @last_increment ||= Time.now.to_f
-      if @last_increment + @batch_push_interval > Time.now.to_f
-        @last_increment = Time.now.to_f
+      now = Time.now.to_f
+      @last_increment ||= now
+      if @last_increment + @batch_push_interval > now
+        @last_increment = now
         return true
       end
     end

--- a/lib/sidekiq/batch.rb
+++ b/lib/sidekiq/batch.rb
@@ -88,8 +88,9 @@ module Sidekiq
         ensure
           Thread.current[:batch] = parent
         end
-        conditional_redis_increment!(true)
+
         return [] if @queued_jids.size == 0
+        conditional_redis_increment!(true)
 
         Sidekiq.redis do |r|
           r.multi do |pipeline|

--- a/sidekiq-batch.gemspec
+++ b/sidekiq-batch.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "sidekiq", ">= 3"
+  spec.add_dependency "sidekiq", ">= 3", "<7"
 
   spec.add_development_dependency "bundler", "~> 2.1"
   spec.add_development_dependency "rake", "~> 13.0"


### PR DESCRIPTION
This PR addresses a race condition present when jobs are added to a batch that complete before the adder is done. I've also pinned the sidekiq requirement under 7 because specs fail with sidekiq 7.

here is a minimal repro:
```ruby
class BatchTestWorker
  include Sidekiq::Worker

  def perform(spawn_children)
    if spawn_children
      log('spawner started')
      batch.jobs do
        5.times do
          BatchTestWorker.perform_async(false)
          sleep 5
        end
      end
      log('spawner ended')
    else
      log('child run')
    end
  end

  def bulk_logger
    @@bulk_logger ||= Logger.new("#{Rails.root}/log/bulk.log")
  end

  def log(msg)
    bulk_logger.info(msg)
  end
end

class TestCallback

  def on_complete(status, options)
    log("callback - complete")
  end

  def on_success(status, options)
    log("callback - success")
  end

  def bulk_logger
    @@bulk_logger ||= Logger.new("#{Rails.root}/log/bulk.log")
  end

  def log(msg)
    bulk_logger.info(msg)
  end
end
```

Called like so:

```ruby
  batch = Sidekiq::Batch.new
  batch.on(:success, TestCallback)
  batch.on(:complete, TestCallback)
  batch.jobs do
    BatchTestWorker.perform_async(true)
  end
```

Pre-fix result:
```
I, [2022-12-16T09:04:50.927633 #3662974]  INFO -- : spawner started
I, [2022-12-16T09:04:51.174733 #3662973]  INFO -- : child run
I, [2022-12-16T09:04:51.179701 #3662973]  INFO -- : callback - success
I, [2022-12-16T09:04:51.425542 #3662972]  INFO -- : callback - complete
I, [2022-12-16T09:04:55.934796 #3662972]  INFO -- : child run
I, [2022-12-16T09:05:00.935667 #3662973]  INFO -- : child run
I, [2022-12-16T09:05:05.936724 #3662972]  INFO -- : child run
I, [2022-12-16T09:05:10.938245 #3662973]  INFO -- : child run
I, [2022-12-16T09:05:15.933752 #3662974]  INFO -- : spawner ended
```

Post-fix result:
```
I, [2022-12-16T13:02:53.446592 #3765663]  INFO -- : spawner started
I, [2022-12-16T13:02:53.447583 #3765663]  INFO -- : spawner sleeping...
I, [2022-12-16T13:02:58.448737 #3765663]  INFO -- : spawner sleeping...
I, [2022-12-16T13:03:03.449961 #3765663]  INFO -- : spawner sleeping...
I, [2022-12-16T13:03:07.345600 #3765662]  INFO -- : child run
I, [2022-12-16T13:03:07.349631 #3765662]  INFO -- : child run
I, [2022-12-16T13:03:07.506709 #3765661]  INFO -- : child run
I, [2022-12-16T13:03:08.451440 #3765663]  INFO -- : spawner sleeping...
I, [2022-12-16T13:03:13.452781 #3765663]  INFO -- : spawner sleeping...
I, [2022-12-16T13:03:15.095986 #3765662]  INFO -- : child run
I, [2022-12-16T13:03:18.453816 #3765663]  INFO -- : spawner ended
I, [2022-12-16T13:03:23.160604 #3765662]  INFO -- : child run
I, [2022-12-16T13:03:23.207821 #3765663]  INFO -- : callback - success
I, [2022-12-16T13:03:23.207821 #3765661]  INFO -- : callback - complete
```