### PR TITLE
Changed exists to exists? 

### DIFF
--- a/lib/sidekiq/batch.rb
+++ b/lib/sidekiq/batch.rb
@@ -168,7 +168,7 @@ module Sidekiq
     end
 
     def valid?(batch = self)
-      valid = !Sidekiq.redis { |r| r.exists("invalidated-bid-#{batch.bid}") }
+      valid = !Sidekiq.redis { |r| r.exists?("invalidated-bid-#{batch.bid}") }
       batch.parent ? valid && valid?(batch.parent) : valid
     end
 

--- a/sidekiq-batch.gemspec
+++ b/sidekiq-batch.gemspec
@@ -24,5 +24,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler", "~> 2.1"
   spec.add_development_dependency "rake", "~> 13.0"
   spec.add_development_dependency "rspec", "~> 3.0"
-  spec.add_development_dependency "fakeredis", "~> 0.8.0"
+  spec.add_development_dependency "fakeredis", "~> 0.9.0"
 end


### PR DESCRIPTION
In order to keep the same boolean behavior that had before Redis 4

The idea is the same explained in #63 , but the fakeredis dependency was also updated so that the tests are able to pass.