### PR TITLE
Update for Sidekiq 8

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     services:
       redis:
-        image: redis
+        image: redis:7
         # Set health checks to wait until redis has started
         options: >-
           --health-cmd "redis-cli ping"
@@ -24,7 +24,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ["3.0", "3.1", "3.2", ruby-head]
+        ruby: ["3.2", "3.3", "3.4", ruby-head]
 
     steps:
     - uses: actions/checkout@v2

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,0 @@
-sudo: false
-language: ruby
-rvm:
-  - 2.3.1
-before_install: gem install bundler -v 1.12.5
-after_success:
-  - bundle exec codeclimate-test-reporter

--- a/Gemfile
+++ b/Gemfile
@@ -4,5 +4,4 @@ gemspec
 
 group :test do
   gem "simplecov"
-  gem "codeclimate-test-reporter", "~> 1.0.0"
 end

--- a/README.md
+++ b/README.md
@@ -1,16 +1,12 @@
 [gem]: https://rubygems.org/gems/sidekiq-batch
-[travis]: https://travis-ci.org/breamware/sidekiq-batch
-[codeclimate]: https://codeclimate.com/github/breamware/sidekiq-batch
+[ci]: https://github.com/breamware/sidekiq-batch/actions/workflows/ci.yml
 
 # Sidekiq::Batch
 
 [![Join the chat at https://gitter.im/breamware/sidekiq-batch](https://badges.gitter.im/breamware/sidekiq-batch.svg)](https://gitter.im/breamware/sidekiq-batch?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
 [![Gem Version](https://badge.fury.io/rb/sidekiq-batch.svg)][gem]
-[![Build Status](https://travis-ci.org/breamware/sidekiq-batch.svg?branch=master)][travis]
-[![Code Climate](https://codeclimate.com/github/breamware/sidekiq-batch/badges/gpa.svg)][codeclimate]
-[![Code Climate](https://codeclimate.com/github/breamware/sidekiq-batch/badges/coverage.svg)][codeclimate]
-[![Code Climate](https://codeclimate.com/github/breamware/sidekiq-batch/badges/issue_count.svg)][codeclimate]
+[![CI](https://github.com/breamware/sidekiq-batch/actions/workflows/ci.yml/badge.svg?branch=master)][ci]
 
 Simple Sidekiq Batch Job implementation.
 

--- a/compose.yml
+++ b/compose.yml
@@ -1,0 +1,16 @@
+services:
+  redis:
+    image: redis:7-alpine
+    platform: linux/amd64
+    volumes:
+      - redis:/data
+    ports:
+      - 6379:6379
+    healthcheck:
+      test: redis-cli ping
+      interval: 1s
+      timeout: 3s
+      retries: 30
+
+volumes:
+  redis:

--- a/lib/sidekiq/batch.rb
+++ b/lib/sidekiq/batch.rb
@@ -152,7 +152,10 @@ module Sidekiq
 
     def invalidate_all
       Sidekiq.redis do |r|
-        r.setex("invalidated-bid-#{bid}", BID_EXPIRE_TTL, 1)
+        r.multi do |pipeline|
+          pipeline.set("invalidated-bid-#{@bid}", 1)
+          pipeline.expire("invalidated-bid-#{@bid}", BID_EXPIRE_TTL)
+        end
       end
     end
 

--- a/sidekiq-batch.gemspec
+++ b/sidekiq-batch.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "sidekiq", ">= 7", "<8"
+  spec.add_dependency "sidekiq", ">= 8", "< 9"
 
   spec.add_development_dependency "bundler", "~> 2.1"
   spec.add_development_dependency "rake", "~> 13.0"

--- a/sidekiq-batch.gemspec
+++ b/sidekiq-batch.gemspec
@@ -19,6 +19,8 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
+  spec.required_ruby_version = ">= 3.2.0"
+
   spec.add_dependency "sidekiq", ">= 8", "< 9"
 
   spec.add_development_dependency "bundler", "~> 2.1"


### PR DESCRIPTION
- [x] Remove unsupported `Ruby` versions (3.0 and 3.1)
- [x] Use`SET` + `EXPIRE` instead of deprecated `SETEX`
- [x] Update `Sidekiq` requirement to ">= 8", "< 9"
- [x] Add `compose.yml` file for development purposes
- [x] Remove CodeClimate and Travis