### PR TITLE
Fix compatibility with json gem `2.11.0`

### DIFF
--- a/lib/sidekiq/batch.rb
+++ b/lib/sidekiq/batch.rb
@@ -47,7 +47,7 @@ module Sidekiq
       callback_key = "#{@bidkey}-callbacks-#{event}"
       Sidekiq.redis do |r|
         r.multi do |pipeline|
-          pipeline.sadd(callback_key, [JSON.unparse({
+          pipeline.sadd(callback_key, [JSON.generate({
             callback: callback,
             opts: options
           })])


### PR DESCRIPTION
`JSON.unparse` has been nodoc/deprecated for 16 years and now it was removed in the latest release.

`JSON.generate` has been around since forever, so it can just be used in all cases (especially considering it's Ruby 3.2 only)

Ref: https://github.com/ruby/json/pull/775. It might be added back, but it will at least be deprecated.