### PR TITLE
Added on_death callback

### DIFF
--- a/lib/sidekiq/batch.rb
+++ b/lib/sidekiq/batch.rb
@@ -315,6 +315,7 @@ module Sidekiq
             "BID-#{bid}",
             "BID-#{bid}-callbacks-complete",
             "BID-#{bid}-callbacks-success",
+            "BID-#{bid}-callbacks-death",
             "BID-#{bid}-failed",
 
             "BID-#{bid}-success",

--- a/lib/sidekiq/batch.rb
+++ b/lib/sidekiq/batch.rb
@@ -43,7 +43,7 @@ module Sidekiq
     end
 
     def on(event, callback, options = {})
-      return unless %w(success complete).include?(event.to_s)
+      return unless %w(success complete death).include?(event.to_s)
       callback_key = "#{@bidkey}-callbacks-#{event}"
       Sidekiq.redis do |r|
         r.multi do |pipeline|
@@ -242,6 +242,10 @@ module Sidekiq
           enqueue_callbacks(:complete, bid)
           enqueue_callbacks(:success, bid) if all_success
         end
+      end
+
+      def process_dead_job(bid, jid)
+        enqueue_callbacks(:death, bid)
       end
 
       def enqueue_callbacks(event, bid)

--- a/lib/sidekiq/batch/callback.rb
+++ b/lib/sidekiq/batch/callback.rb
@@ -94,6 +94,12 @@ module Sidekiq
           end
         end
 
+        def death(bid, status, parent_bid)
+          # Death callback is triggered when a job permanently fails after all retries
+          # Unlike success/complete, we don't need to trigger parent callbacks
+          # or update completion counters since the job has already been marked as failed
+        end
+
         def cleanup_redis bid, callback_bid=nil
           Sidekiq::Batch.cleanup_redis bid
           Sidekiq::Batch.cleanup_redis callback_bid if callback_bid

--- a/lib/sidekiq/batch/callback.rb
+++ b/lib/sidekiq/batch/callback.rb
@@ -5,7 +5,7 @@ module Sidekiq
         include Sidekiq::Worker
 
         def perform(clazz, event, opts, bid, parent_bid)
-          return unless %w(success complete).include?(event)
+          return unless %w(success complete death).include?(event)
           clazz, method = clazz.split("#") if (clazz && clazz.class == String && clazz.include?("#"))
           method = "on_#{event}" if method.nil?
           status = Sidekiq::Batch::Status.new(bid)

--- a/lib/sidekiq/batch/middleware.rb
+++ b/lib/sidekiq/batch/middleware.rb
@@ -45,6 +45,11 @@ module Sidekiq
           config.server_middleware do |chain|
             chain.add Sidekiq::Batch::Middleware::ServerMiddleware
           end
+          config.death_handlers << ->(job, ex) do
+            if (bid = job["bid"])
+              Batch.process_dead_job(bid, job["jid"])
+            end
+          end
         end
         Sidekiq::Worker.send(:include, Sidekiq::Batch::Extension::Worker)
       end

--- a/spec/sidekiq/batch/callback_spec.rb
+++ b/spec/sidekiq/batch/callback_spec.rb
@@ -6,7 +6,7 @@ describe Sidekiq::Batch::Callback::Worker do
       subject.perform('SampleCallback', 'complete', {}, 'ABCD', 'EFGH')
     end
 
-    it 'does not do anything if event is different from complete or success' do
+    it 'does not do anything if event is different from complete, success, or death' do
       expect(SampleCallback).not_to receive(:new)
       subject.perform('SampleCallback', 'ups', {}, 'ABCD', 'EFGH')
     end
@@ -33,6 +33,14 @@ describe Sidekiq::Batch::Callback::Worker do
       expect(callback_instance).to receive(:sample_method)
         .with(instance_of(Sidekiq::Batch::Status), {})
       subject.perform('SampleCallback#sample_method', 'complete', {}, 'ABCD', 'EFGH')
+    end
+
+    it 'calls on_death if defined' do
+      callback_instance = double('SampleCallback')
+      expect(SampleCallback).to receive(:new).and_return(callback_instance)
+      expect(callback_instance).to receive(:on_death)
+        .with(instance_of(Sidekiq::Batch::Status), {})
+      subject.perform('SampleCallback', 'death', {}, 'ABCD', 'EFGH')
     end
   end
 end

--- a/spec/sidekiq/batch/middleware_spec.rb
+++ b/spec/sidekiq/batch/middleware_spec.rb
@@ -93,11 +93,14 @@ describe Sidekiq::Batch::Middleware do
 
   context 'server' do
     let(:server_middleware) { double(Sidekiq::Middleware::Chain) }
+    let(:death_handlers) { double("death_handlers") }
 
     it 'adds client and server middleware' do
       expect(Sidekiq).to receive(:configure_server).and_yield(config)
       expect(config).to receive(:client_middleware).and_yield(client_middleware)
       expect(config).to receive(:server_middleware).and_yield(server_middleware)
+      expect(config).to receive(:death_handlers).and_return(death_handlers)
+      expect(death_handlers).to receive(:<<).with(instance_of(Proc))
       expect(client_middleware).to receive(:add).with(Sidekiq::Batch::Middleware::ClientMiddleware)
       expect(server_middleware).to receive(:add).with(Sidekiq::Batch::Middleware::ServerMiddleware)
       Sidekiq::Batch::Middleware.configure

--- a/spec/sidekiq/batch_spec.rb
+++ b/spec/sidekiq/batch_spec.rb
@@ -208,6 +208,17 @@ describe Sidekiq::Batch do
     end
   end
 
+  describe '#process_dead_job' do
+    let(:batch) { Sidekiq::Batch.new }
+    let(:bid) { batch.bid }
+    let(:jid) { 'DEAD-JOB-ID' }
+
+    it 'calls enqueue_callbacks with death event' do
+      expect(Sidekiq::Batch).to receive(:enqueue_callbacks).with(:death, bid)
+      Sidekiq::Batch.process_dead_job(bid, jid)
+    end
+  end
+
   describe '#increment_job_queue' do
     let(:bid) { 'BID' }
     let(:batch) { Sidekiq::Batch.new }

--- a/spec/sidekiq/batch_spec.rb
+++ b/spec/sidekiq/batch_spec.rb
@@ -217,6 +217,12 @@ describe Sidekiq::Batch do
       expect(Sidekiq::Batch).to receive(:enqueue_callbacks).with(:death, bid)
       Sidekiq::Batch.process_dead_job(bid, jid)
     end
+
+    it 'completes without error when no death callbacks are defined' do
+      # This ensures the death finalization works even without user callbacks
+      # (tests the bug fix where Finalize#death was missing)
+      expect { Sidekiq::Batch.process_dead_job(bid, jid) }.not_to raise_error
+    end
   end
 
   describe '#increment_job_queue' do


### PR DESCRIPTION
I took a swing at adding the `on_death` callback. I haven't actually used this functionality in Sidekiq Pro, but I tried to implement the behavior exactly how the documents describe it. This callback should happen **only once** when the first job in the batch fully dies (exhausts all retries). It will not get called for every job in the batch that dies.

I've been running this branch in production since yesterday and seeing it behave the way I expect. Please let me know if you want me to adjust implementation, add more specs, etc!

Thank you!

Resolves #51 