### PR TITLE
Fixed success callback not firing after jobs fail initially then succeed on retries

### DIFF
--- a/lib/sidekiq/batch.rb
+++ b/lib/sidekiq/batch.rb
@@ -282,6 +282,15 @@ module Sidekiq
           status = Status.new bid
           finalizer.dispatch(status, cb_opts)
 
+          # After finalizing the main batch's callbacks, mark this callback batch as successful
+          # in its parent batch (if it has one). This is needed because callback batches created
+          # during job failures become children of the main batch (due to Thread.current[:batch]
+          # still being set in the rescue block), but they never go through the normal success
+          # flow that would mark them as successful in their parent.
+          if event_name == "complete" && parent_bid
+            finalizer.success(bid, status, parent_bid)
+          end
+
           return
         end
 

--- a/spec/sidekiq/batch_spec.rb
+++ b/spec/sidekiq/batch_spec.rb
@@ -301,4 +301,51 @@ describe Sidekiq::Batch do
       end
     end
   end
+
+  describe 'job failure then retry success scenario' do
+    it 'fires on_success callback when jobs fail then retry successfully' do
+      # Setup: Create batch with 2 jobs
+      batch = Sidekiq::Batch.new
+      batch.on(:complete, SampleCallback)
+      batch.on(:success, SampleCallback)
+
+      batch.jobs do
+        Sidekiq.redis { |r| r.hincrby("BID-#{batch.bid}", "pending", 2) }
+        Sidekiq.redis { |r| r.hincrby("BID-#{batch.bid}", "total", 2) }
+      end
+
+      # One job succeeds, one job fails
+      Sidekiq::Batch.process_successful_job(batch.bid, "jid-success")
+
+      # Simulate job failure in middleware context where Thread.current[:batch] is still set
+      # (it only gets cleared in the ensure block AFTER the rescue block runs)
+      Thread.current[:batch] = batch
+      Sidekiq::Batch.process_failed_job(batch.bid, "jid-fail")
+      Thread.current[:batch] = nil
+      # This creates a callback batch as a child of the main batch
+
+      # Find the callback batch (it has our batch as its parent)
+      callback_batch_bid = Sidekiq.redis { |r| r.keys("BID-*") }
+        .reject { |k| k =~ /-(callbacks|failed|success|complete|jids)/ }
+        .map { |k| k.sub("BID-", "") }
+        .find { |bid| bid != batch.bid && Sidekiq.redis { |r| r.hget("BID-#{bid}", "parent_bid") } == batch.bid }
+
+      # Complete the callback batch
+      Sidekiq.redis { |r| r.smembers("BID-#{callback_batch_bid}-jids") }.each do |jid|
+        Sidekiq::Batch::Middleware::ServerMiddleware.new.call(nil, {"bid" => callback_batch_bid, "jid" => jid}, nil) { }
+      end
+
+      # Without the fix: callback batch is NOT in parent's success set (children=1, success=0)
+      # With the fix: callback batch IS in parent's success set (children=1, success=1)
+      success_count = Sidekiq.redis { |r| r.scard("BID-#{batch.bid}-success") }
+      expect(success_count).to eq(1)
+
+      # Failed job retries and succeeds
+      Sidekiq::Batch.process_successful_job(batch.bid, "jid-fail")
+
+      # Verify on_success callback was enqueued
+      success_enqueued = Sidekiq.redis { |r| r.hget("BID-#{batch.bid}", "success") }
+      expect(success_enqueued).to eq("true")
+    end
+  end
 end


### PR DESCRIPTION
I've been encountering this problem in my app intermittently and it took a while to track down, but I was finally able to repro it and produce a fix. Please let me know if this isn't the correct approach or if there's anything else I can clarify.

### Repro steps
* Create a batch of jobs with retries enabled
* Ensure at least one job fails on it's first run
* Observe that the `on_complete` callback fires as soon as all jobs have completed once (as expected)
* Ensure the failed job succeeds on a subsequent retry
* Observe that the `on_success` callback never fires

### The Issue
Callback batches created during job failures become child batches of the main batch (because `Thread.current[:batch]` is still set when `process_failed_job` runs in the rescue block). When these callback batches complete, they run the parent batch's finalize logic synchronously to check if the parent should fire `:success`. However, at that moment the callback batch hasn't yet added itself to the parent's success set, so the check fails (children=1, success=0). When retried jobs later succeed, the parent batch sees pending=0 but children=1, success=0, so all_success remains false. Regular child batches don't have this issue because they add themselves to the parent's success set via `Finalize#success` before triggering parent callback checks, whereas callback batches run the parent's finalize logic before marking themselves as successful.

### The Solution
When a callback batch completes, explicitly call `Finalize#success` to add it to the parent's success set before running the parent's finalize logic. This ensures the parent sees the correct children == success count when checking whether to fire `:success`.